### PR TITLE
Remove recently edited pills from UI

### DIFF
--- a/CONTEXT_PILL_STACKING_FIX.md
+++ b/CONTEXT_PILL_STACKING_FIX.md
@@ -1,0 +1,59 @@
+# Context Pill Stacking Fix Plan
+
+## Problem Statement
+The UI currently has "recently edited" pills that are stacking or overlapping with other UI elements. Instead of repositioning these pills, we need to completely remove them from the UI.
+
+## Solution Overview
+Remove the "recently edited" pills entirely from the UI rather than attempting to reposition or reorganize them.
+
+## Implementation Steps
+
+### 1. Identify Recently Edited Pills Components
+- Locate all components that render "recently edited" pills
+- Find their parent containers and any associated state management
+- Identify any event handlers or listeners that trigger their display
+
+### 2. Remove UI Components
+- Delete or comment out the JSX/TSX code that renders recently edited pills
+- Remove any CSS/styling specific to these pills
+- Clean up any animations or transitions related to these pills
+
+### 3. Clean Up State Management
+- Remove state variables that track recently edited items for pill display
+- Remove any Redux actions/reducers or context providers related to these pills
+- Clean up any local component state used for these pills
+
+### 4. Remove Event Handlers
+- Remove event listeners that trigger the display of recently edited pills
+- Remove any file system watchers or other mechanisms that populate these pills
+- Clean up any API calls that fetch recently edited data for pill display
+
+### 5. Update Layout
+- Adjust spacing and layout of remaining UI elements
+- Ensure no empty containers or gaps are left where pills were removed
+- Test responsive behavior after removal
+
+### 6. Clean Up Dead Code
+- Remove any utility functions specific to recently edited pills
+- Remove any types/interfaces used only for these pills
+- Remove any tests specific to these pills
+
+## Files Likely to be Modified
+- Components that render pills (likely in a Pills, Tags, or similar directory)
+- State management files (Redux store, Context providers)
+- CSS/SCSS files for pill styling
+- Layout components that contained these pills
+- Any configuration files that enabled/disabled these pills
+
+## Testing Approach
+1. Verify pills no longer appear in the UI
+2. Check that no console errors occur from removed code
+3. Ensure layout looks correct without the pills
+4. Test that file editing still works normally without pill updates
+5. Verify no performance impact from removal
+
+## Success Criteria
+- Recently edited pills are completely removed from the UI
+- No visual artifacts or layout issues after removal
+- No console errors or warnings
+- Application continues to function normally without these pills


### PR DESCRIPTION
Create a plan to remove 'recently edited' pills from the UI to address stacking issues.

---

[Open in Web](https://www.cursor.com/agents?id=bc-18b38146-0dd5-4e04-a192-ca315d887bdd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-18b38146-0dd5-4e04-a192-ca315d887bdd)