### PR TITLE
Investigate missing token counter in chat ui

### DIFF
--- a/backend/internal/handlers/signalr_handler.go
+++ b/backend/internal/handlers/signalr_handler.go
@@ -181,6 +181,7 @@ func (h *SignalRHandler) HandleSignalRChat(w http.ResponseWriter, r *http.Reques
 		h.logger.WithError(err).Error("Failed to process chat message")
 		// Send error back to client via SignalR
 		h.signalRBridge.SendAIResponse(req.SessionID, map[string]interface{}{
+			"type":       "error", // Add type to distinguish error messages
 			"messageId":  req.MessageID,
 			"error":      err.Error(),
 			"isComplete": true, // Mark as complete on error
@@ -217,6 +218,7 @@ func (h *SignalRHandler) HandleSignalRChat(w http.ResponseWriter, r *http.Reques
 
 	// Send response back to client via SignalR
 	err = h.signalRBridge.SendAIResponse(req.SessionID, map[string]interface{}{
+		"type":       "ai_response", // Add type to distinguish from other messages
 		"messageId":  req.MessageID, // Include the message ID from the request
 		"content":    response.Content,
 		"actions":    response.Actions,


### PR DESCRIPTION
Add `type` field to AI response and error payloads to enable frontend token counter display.

The frontend's `handleAIResponse` function expects a `type` field (e.g., `ai_response` or `error`) to correctly process messages and extract `tokenUsage` data. Previously, AI responses from the backend lacked this field, preventing the token counter from displaying.

---

[Open in Web](https://www.cursor.com/agents?id=bc-42b304ea-ef72-412e-ba00-1e5c99988701) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-42b304ea-ef72-412e-ba00-1e5c99988701)