### PR TITLE
Investigate missing token counter in chat UI

### DIFF
--- a/excel-addin/src/components/chat/EnhancedChatInterface.tsx
+++ b/excel-addin/src/components/chat/EnhancedChatInterface.tsx
@@ -699,9 +699,7 @@ export const EnhancedChatInterface: React.FC<EnhancedChatInterfaceProps> = ({
               {/* Right side: Action buttons */}
               <div className="flex items-center gap-2">
                 {/* Token Counter - in place of former "Generating..." text */}
-                {tokenUsage && (
-                  <TokenCounter tokenUsage={tokenUsage} />
-                )}
+                <TokenCounter tokenUsage={tokenUsage} />
                 
                 {/* Stop button (when generating) */}
                 {aiIsGenerating && (

--- a/excel-addin/src/components/chat/TokenCounter.tsx
+++ b/excel-addin/src/components/chat/TokenCounter.tsx
@@ -6,9 +6,15 @@ interface TokenCounterProps {
 }
 
 export const TokenCounter: React.FC<TokenCounterProps> = ({ tokenUsage }) => {
-  if (!tokenUsage) return null;
+  // Use default values when tokenUsage is null
+  const usage = tokenUsage || {
+    input: 0,
+    output: 0,
+    total: 0,
+    max: 200000
+  };
 
-  const percentage = (tokenUsage.total / tokenUsage.max) * 100;
+  const percentage = (usage.total / usage.max) * 100;
   const progressColor = percentage >= 90 ? 'text-red-500' : 
                        percentage >= 80 ? 'text-yellow-500' : 
                        'text-text-secondary';
@@ -16,7 +22,7 @@ export const TokenCounter: React.FC<TokenCounterProps> = ({ tokenUsage }) => {
   return (
     <div className="flex items-center gap-2 px-3 py-1.5 font-callout text-text-secondary">
       <span className={`${progressColor} transition-colors`}>
-        {tokenUsage.total.toLocaleString()} / {tokenUsage.max.toLocaleString()}
+        {usage.total.toLocaleString()} / {usage.max.toLocaleString()}
       </span>
       <span className="text-text-tertiary text-xs">
         tokens


### PR DESCRIPTION
Always display the token counter, even when token usage is zero or not yet available.

Previously, the `TokenCounter` component would return `null` if `tokenUsage` was `null`, and it was also conditionally rendered only when `tokenUsage` was truthy. This prevented it from showing default values like '0/200,000' at the start of a chat session.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b41b41ef-426c-471a-b281-6f258a13f64f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b41b41ef-426c-471a-b281-6f258a13f64f)