### PR TITLE
Debug streaming AI chat response stops

### DIFF
--- a/STREAMING_DEBUG_ANALYSIS.md
+++ b/STREAMING_DEBUG_ANALYSIS.md
@@ -1,0 +1,102 @@
+# Streaming Debug Analysis
+
+## Issue Summary
+The AI chat response was stopping after just 1 streaming output in the UI, even though all chunks were being received correctly.
+
+## Root Cause
+The frontend was expecting streaming chunks to have a `delta` field, but the backend was sending chunks with a `content` field instead. This mismatch caused only the first chunk to be displayed.
+
+## Investigation Process
+
+### 1. Log Analysis
+- **Browser logs**: Showed all 41 chunks were received correctly
+- **Backend logs**: Confirmed all chunks were sent with proper timing
+- **SignalR logs**: Verified the hub was forwarding all chunks
+
+### 2. Key Findings
+- All chunks were received by the browser (41 total)
+- The streaming completed successfully (duration: 3868ms)
+- Only the first chunk was displayed in the UI
+- The chunk structure from backend had `content` field, not `delta`
+
+### 3. Code Analysis
+```typescript
+// Original problematic code:
+if (chunk.delta) {
+  chatManager.updateStreamingMessage(messageId, {
+    content: (prev: string) => prev + chunk.delta
+  });
+}
+```
+
+The backend was sending:
+```json
+{
+  "id": "...",
+  "type": "text",
+  "content": "chunk text here",
+  "delta": "",
+  "done": false
+}
+```
+
+## Fix Applied
+
+### 1. Updated chunk handling to support both fields:
+```typescript
+const textToAppend = chunk.delta || chunk.content;
+if (textToAppend) {
+  chatManager.updateStreamingMessage(messageId, {
+    content: (prev: string) => prev + textToAppend
+  });
+}
+```
+
+### 2. Enhanced logging for better debugging:
+```typescript
+console.log(`[Stream] Chunk type: ${chunk.type}, has delta: ${!!chunk.delta}, has content: ${!!chunk.content}, delta length: ${chunk.delta?.length || 0}, content length: ${chunk.content?.length || 0}`);
+```
+
+### 3. Updated TypeScript types with documentation:
+```typescript
+export interface StreamChunk {
+    content?: string;  // Full content (used by some backends)
+    delta?: string;    // Incremental content (used for streaming)
+    // ... other fields
+}
+```
+
+## Testing Recommendations
+
+1. Test with different AI providers (OpenAI, Anthropic, Azure) as they may use different chunk formats
+2. Verify streaming works with:
+   - Short responses
+   - Long responses
+   - Responses with tool calls
+   - Responses with code blocks
+3. Monitor the enhanced logs to ensure chunks are processed correctly
+
+## Future Improvements
+
+1. **Backend Standardization**: Consider standardizing the chunk format across all AI providers
+2. **Error Recovery**: Add fallback handling if neither `delta` nor `content` is present
+3. **Performance Monitoring**: Track chunk processing time to identify bottlenecks
+4. **Unit Tests**: Add tests for different chunk formats to prevent regression
+
+## Debug Commands
+
+To debug streaming issues in the future:
+
+1. Open browser console
+2. Look for `[Stream]` prefixed logs
+3. Check:
+   - Total chunks received
+   - Chunk types and content/delta presence
+   - Stream completion status
+   - Any parsing errors
+
+Example healthy log:
+```
+[Stream] Chunk #1 received at 100ms, length: 50
+[Stream] Chunk type: text, has delta: false, has content: true, delta length: 0, content length: 15
+```

--- a/excel-addin/src/hooks/useMessageHandlers.ts
+++ b/excel-addin/src/hooks/useMessageHandlers.ts
@@ -759,10 +759,11 @@ export const useMessageHandlers = (
           
           try {
             const chunk: StreamChunk = JSON.parse(data);
-            console.log(`[Stream] Chunk type: ${chunk.type}, has delta: ${!!chunk.delta}`);
+            console.log(`[Stream] Chunk type: ${chunk.type}, has delta: ${!!chunk.delta}, has content: ${!!chunk.content}, delta length: ${chunk.delta?.length || 0}, content length: ${chunk.content?.length || 0}`);
             handleStreamChunk(streamingMessageId, chunk);
           } catch (error) {
             console.error('Failed to parse chunk:', error);
+            console.error('Raw chunk data:', data);
           }
         },
         onComplete: () => {
@@ -802,9 +803,11 @@ export const useMessageHandlers = (
   const handleStreamChunk = useCallback((messageId: string, chunk: StreamChunk) => {
     switch (chunk.type) {
       case 'text':
-        if (chunk.delta) {
+        // Use delta if available, otherwise fall back to content
+        const textToAppend = chunk.delta || chunk.content;
+        if (textToAppend) {
           chatManager.updateStreamingMessage(messageId, {
-            content: (prev: string) => prev + chunk.delta
+            content: (prev: string) => prev + textToAppend
           });
         }
         break;

--- a/excel-addin/src/types/streaming.ts
+++ b/excel-addin/src/types/streaming.ts
@@ -1,8 +1,8 @@
 export interface StreamChunk {
     id: string;
     type: 'text' | 'tool_start' | 'tool_progress' | 'tool_complete' | 'done';
-    content?: string;
-    delta?: string;
+    content?: string;  // Full content (used by some backends)
+    delta?: string;    // Incremental content (used for streaming)
     toolCall?: {
         id: string;
         name: string;


### PR DESCRIPTION
Fix AI chat streaming by handling both `content` and `delta` fields in chunks and add enhanced logging.

The frontend was expecting streaming chunks to have a `delta` field, but the backend was sending chunks with a `content` field. This mismatch caused only the first chunk to be displayed, even though all chunks were received. This PR updates the chunk processing logic to correctly use either `delta` or `content` and adds detailed logging for future debugging.

---

[Open in Web](https://www.cursor.com/agents?id=bc-03513101-edde-4038-9056-2d8c5acb6f8f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-03513101-edde-4038-9056-2d8c5acb6f8f)